### PR TITLE
Fixed package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 ![steampunkFOURcrop](https://github.com/Kinds-of-Intelligence-CFI/animal-ai/assets/65875290/df798f4a-cb2c-416f-a150-093b9382a621)
 Animal-AI Python Project
 
-This repository is responsible for managing and updating primarily the PyPI package (https://pypi.org/project/animalai/) for Animal-AI package dependencies. 
-
-The main project repository is located [here](https://github.com/Kinds-of-Intelligence-CFI/animal-ai)
-
-The Animal-AI Unity project repository is located [here](https://github.com/Kinds-of-Intelligence-CFI/animal-ai-unity-project)
+The main Animal-AI repository is located [here](https://github.com/Kinds-of-Intelligence-CFI/animal-ai)
 
 ![PyPI Downloads](https://img.shields.io/pypi/dm/animalai) ![PyPI Downloads](https://img.shields.io/pypi/dw/animalai) ![PyPI Downloads](https://img.shields.io/pypi/dd/animalai)
 
@@ -21,6 +17,8 @@ For more information about the ways you can contribute to Animal-AI, visit our w
 If you are new to contributing to open source, [this](https://opensource.guide/how-to-contribute/) guide helps explain why, what, and how to successfully get involved.
 
 ## Version History
+- v3.0.6
+  - Fixed dependency requirement for running an OpenAI Gym session.
 - v3.0.5
   - Removed redundant packages in setup.py.
   - Added download stats.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you are new to contributing to open source, [this](https://opensource.guide/h
 ## Version History
 - v3.0.6
   - Fixed dependency requirement for running an OpenAI Gym session.
+  - Added optional package (Shimmy) which the user may need if using Stable-baselines3 (via command: 'pip install animalai[shimmy]'.
 - v3.0.5
   - Removed redundant packages in setup.py.
   - Added download stats.

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 
 setup(
     name="animalai",
-    version="3.0.5",
-    description="Animal AI 3 Python API",
+    version="3.0.6",
+    description="Animal AI Python API",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url="https://github.com/Kinds-of-Intelligence-CFI/animalai-package",
@@ -35,6 +35,8 @@ setup(
         "mlagents==0.30.0",
         "protobuf==3.20.3",
         "numpy==1.21.2",
+        # For OpenAI Gym(nasium) environments. Stable-Baselines3 (SB3) has transitioned to using Gymnasium internally. Requires Shimmy.
+        "shimmy== 1.3.0",
     ],
     python_requires=">=3.6, <3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ setup(
         "mlagents==0.30.0",
         "protobuf==3.20.3",
         "numpy==1.21.2",
-        # For OpenAI Gym(nasium) environments. Stable-Baselines3 (SB3) has transitioned to using Gymnasium internally. Requires Shimmy.
-        "shimmy== 1.3.0",
     ],
+    # For OpenAI Gym(nasium) environments. Stable-Baselines3 (SB3) has transitioned to using Gymnasium internally. Requires Shimmy. Currently an optional and can be used like so: pip install animalai[shimmy]'.
+    extras_require={
+        'shimmy': ['shimmy==1.3.0'],
+    },
     python_requires=">=3.6, <3.10",
 )


### PR DESCRIPTION
Fixed a dependency issue with training suing stable-baselines3. 

The PR simply adds the "shimmy" package which is required by stable-baselines3 when using gym. 

