### PR TITLE
example envs changed to new var names

### DIFF
--- a/animalai/arenas/GoodGoal_Fixed.yml
+++ b/animalai/arenas/GoodGoal_Fixed.yml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 1
-    t: 500
+    passMark: 1
+    timeLimit:500
     items:
       - !Item
         name: Agent

--- a/animalai/arenas/GoodGoal_Random.yml
+++ b/animalai/arenas/GoodGoal_Random.yml
@@ -1,8 +1,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 1
-    t: 500
+    passMark: 1
+    timeLimit:500
     items:
       - !Item
         name: Agent

--- a/tests/test-Configs/exampleArena.yml
+++ b/tests/test-Configs/exampleArena.yml
@@ -2,8 +2,8 @@
 !ArenaConfig
 arenas:
   0: !Arena
-    pass_mark: 1
-    t: 100
+    passMark: 1
+    timeLimit:100
     items:
       - !Item
         name: Agent
@@ -17,8 +17,8 @@ arenas:
         sizes:
           - !Vector3 { x: 2, y: 2, z: 2 }
   1: !Arena
-    pass_mark: 1
-    t: 100
+    passMark: 1
+    timeLimit:100
     items:
       - !Item
         name: Agent
@@ -32,8 +32,8 @@ arenas:
         sizes:
           - !Vector3 { x: 2, y: 2, z: 2 }
   -1: !Arena # checking if -1 value is properly handled (should become 3rd arena)
-    pass_mark: 1
-    t: 100
+    passMark: 1
+    timeLimit:100
     items:
       - !Item
         name: Agent


### PR DESCRIPTION


### PR Description

updated the example environments to use the new versions of timeLimit and passMark.

### Proposed change(s)

Changed each example env from "t: " to "timeLimit:" and "pass_mark:" to "passMark:"

### Useful links (Github issues, discussion threads, etc.)



### Types of change(s)
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
